### PR TITLE
Php7 mapserver fixes

### DIFF
--- a/public/admin/lib/gcFeature.class.php
+++ b/public/admin/lib/gcFeature.class.php
@@ -408,7 +408,7 @@ class gcFeature
                     }
                     $layText[] = "DATA \"$sData\"";
                     if (!empty($this->aFeature["data_filter"])) {
-                        $layText[] = "FILTER \"" . $this->aFeature["data_filter"] . "\"";
+                        $layText[] = "PROCESSING \"NATIVE_FILTER=" . $this->aFeature["data_filter"] . "\"";
                     }
                     if ($closedDefer) {
                         $layText[] = "PROCESSING \"CLOSE_CONNECTION=DEFER\"";
@@ -434,7 +434,7 @@ class gcFeature
                     }
                     $layText[] = "DATA \"$sData\"";
                     if (!empty($this->aFeature["data_filter"])) {
-                        $layText[] = "FILTER \"" . $this->aFeature["data_filter"] . "\"";
+                        $layText[] = "PROCESSING \"NATIVE_FILTER=" . $this->aFeature["data_filter"] . "\"";
                     }
                     $layText[] = "PROCESSING \"CLOSE_CONNECTION=DEFER\"";
                     if ($this->aFeature["queryable"] == 1) {

--- a/public/admin/lib/gcFeature.class.php
+++ b/public/admin/lib/gcFeature.class.php
@@ -316,7 +316,9 @@ class gcFeature
             $layText[] = "FOOTER \"" . $this->aFeature["footer"] . "\"";
         };
         if (!empty($this->aFeature["opacity"])) {
-            $layText[] = "OPACITY " . $this->aFeature["opacity"];
+            $layText[] = "COMPOSITE";
+            $layText[] = "\tOPACITY " . $this->aFeature["opacity"];
+            $layText[] = "END";
         }
         if (!empty($this->aFeature["symbolscale"])) {
             $layText[] = "SYMBOLSCALEDENOM " . $this->aFeature["symbolscale"];

--- a/public/services/ows.php
+++ b/public/services/ows.php
@@ -233,6 +233,9 @@ if ($objRequest->getvaluebyname('srs')) {
 }
 
 if (!empty($_REQUEST['GCFILTERS'])) {
+    // Security issue? If still used somewhere, reevaluate
+    throw new \Exception("Scream test - should not be used anymore");
+
     $v = explode(',', stripslashes($_REQUEST['GCFILTERS']));
     for ($i=0; $i<count($v); $i++) {
         list($layerName, $gcFilter)=explode('@', $v[$i]);
@@ -278,39 +281,7 @@ if (!empty($layersParameter)) {
         }
         $n = 0;
 
-        if (null !== ($layerAuthorizations = $gcService->get('GISCLIENT_USER_LAYER'))) {
-            if (!empty($layerAuthorizations[$layer->name])) {
-                $filter = $layer->getFilterString();
-                $filter = trim($filter, '"');
-                if (!empty($filter)) {
-                    $filter = $filter.' AND ('.$layerAuthorizations[$layer->name].')';
-                } else {
-                    $filter = $layerAuthorizations[$layer->name];
-                }
-                $layer->setFilter($filter);
-            }
-        }
-
-        
         if (!in_array($layer->name, $layersToRemove)) {
-            $filter = $layer->getFilterString();
-
-            if ($filter) {
-                $filter = trim($filter, '"');
-                $p1 = strpos($layer->data, '(');
-                $p2 = strrpos($layer->data, ')', $p1);
-                $part1 = substr($layer->data, 0, $p1);
-                $part2 = substr($layer->data, $p1+1, $p2-$p1-1);
-                $part3 = substr($layer->data, $p2+1);
-
-                $part2 = "SELECT * FROM ({$part2}) AS foo2 WHERE ({$filter})";
-                $sql = "{$part1}({$part2}){$part3}";
-
-                $layer->data = $sql;
-                $layer->set('data', $sql);
-                $layer->setFilter('');
-            }
-
             array_push($layersToInclude, $layer->name);
         }
     }

--- a/public/services/owsgw.php
+++ b/public/services/owsgw.php
@@ -105,6 +105,8 @@ if ($objRequest->getvaluebyname('srs')) {
 }
 
 if (!empty($_REQUEST['GCFILTERS'])) {
+    // Security issue? If still used somewhere, reevaluate
+    throw new \Exception("Scream test - should not be used anymore");
     $v = explode(',', stripslashes($_REQUEST['GCFILTERS']));
     for ($i=0; $i<count($v); $i++) {
         list($layerName,$gcFilter)=explode('@', $v[$i]);

--- a/src/Author/Utils/OwsHandler.php
+++ b/src/Author/Utils/OwsHandler.php
@@ -50,6 +50,9 @@ class OwsHandler
 
     public static function applyGCFilter(&$oLayer, $layerFilter)
     {
+        // GetFilterString result changed in mapserver ~7 version; Should not be used anymore
+        // !! This might also be a security issue!! If still used somewhere, reevaluate
+        throw new \Exception("Scream test - should not be used anymore");
         if ($oLayer->getFilterString()) {
             $layerFilter = str_replace("\"", "", $oLayer->getFilterString()) . " AND " . $layerFilter;
         }


### PR DESCRIPTION
Fix some issues for new mapserver version. Migrated from version 6.4 to 7.6

* Fix native filters for mapserver7 in mapfile (Changed from `FILTER` keyword to `PROCESSING NATIVE_FILTER=...`)
* Fix layer opacity for mapserver7 in mapfile (Moved `OPACITY` keyword from layer into `COMPOSITE` section inside layer)
* Removed workaround for filter in ows that rewrote query (Doesn't work anymore, because getFilterString of mapserver now returns some string that is not SQL and was missing the original filter (still written in SQL).)
* Also removed layerAuthorization check because it used the same method and did not properly work to begin with.
* Added scream test Exception to potentially insecure functions